### PR TITLE
Created feedback linearization based altitude controller, tuned gains

### DIFF
--- a/rotors_control/CMakeLists.txt
+++ b/rotors_control/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(Eigen3 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include ${Eigen3_INCLUDE_DIRS}
-  LIBRARIES lee_position_controller roll_pitch_yawrate_thrust_controller
+  LIBRARIES lee_position_controller roll_pitch_yawrate_thrust_controller height_controller_hover
   CATKIN_DEPENDS geometry_msgs mav_msgs nav_msgs roscpp sensor_msgs
   DEPENDS Eigen3
 )
@@ -35,11 +35,18 @@ add_library(roll_pitch_yawrate_thrust_controller
   src/library/roll_pitch_yawrate_thrust_controller.cpp
 )
 
+add_library(height_controller_hover
+        src/library/height_controller_hover.cpp
+        )
+
 target_link_libraries(lee_position_controller ${catkin_LIBRARIES})
 add_dependencies(lee_position_controller ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(roll_pitch_yawrate_thrust_controller ${catkin_LIBRARIES})
 add_dependencies(roll_pitch_yawrate_thrust_controller ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(height_controller_hover ${catkin_LIBRARIES})
+add_dependencies(height_controller_hover ${catkin_EXPORTED_TARGETS})
 
 add_executable(lee_position_controller_node src/nodes/lee_position_controller_node.cpp)
 add_dependencies(lee_position_controller_node ${catkin_EXPORTED_TARGETS})
@@ -54,9 +61,10 @@ target_link_libraries(roll_pitch_yawrate_thrust_controller_node
 
 add_executable(pid_wrapper_node src/nodes/pid_wrapper.cpp)
 add_dependencies(pid_wrapper_node ${catkin_EXPORTED_TARGETS})
-target_link_libraries(pid_wrapper_node ${catkin_LIBRARIES})
+target_link_libraries(pid_wrapper_node
+        height_controller_hover ${catkin_LIBRARIES})
 
-install(TARGETS lee_position_controller roll_pitch_yawrate_thrust_controller
+install(TARGETS lee_position_controller roll_pitch_yawrate_thrust_controller height_controller_hover
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 

--- a/rotors_control/include/rotors_control/height_controller_hover.h
+++ b/rotors_control/include/rotors_control/height_controller_hover.h
@@ -1,0 +1,39 @@
+
+
+#ifndef HEIGHT_CONTROLLER_HOVER_HPP
+#define HEIGHT_CONTROLLER_HOVER_HPP
+
+// Altitude controller consisting of feedback linearization and a linear controller about hover
+// Takes ref height and outputs thrust command
+class HeightControllerHover
+{
+private:
+
+
+  // Height Setpoint
+  double height_ref = 0.0;
+
+  // Plant variables
+  double roll = 0.0;
+  double pitch = 0.0;
+  double height = 0.0;
+
+  // Controller output
+  double thrust_command = 0.0;
+
+public:
+  // Constants
+  double drone_mass = 0.5;
+
+  // Constructor
+   HeightControllerHover();
+//  ~HeightControllerHover();
+  // Plant state updates
+  void updatePlant(double roll, double pitch, double height);
+  // Controller update
+  void generate_thrust_command(double linear_controller_output);
+  // Accessor functions (for debugging)
+  double getThrust_command() const;
+};
+
+#endif  // HEIGHT_CONTROLLER_HOVER_HPP

--- a/rotors_control/src/library/height_controller_hover.cpp
+++ b/rotors_control/src/library/height_controller_hover.cpp
@@ -1,0 +1,40 @@
+
+#include "rotors_control/height_controller_hover.h"
+
+#include <cmath>
+#include <exception>
+#include <iostream>
+
+#define G_CONST (double)9.80665
+
+/*!
+ * @brief Constructor for HeightControllerPID class
+ *
+ */
+HeightControllerHover::HeightControllerHover(){}
+
+
+/*!
+ * @brief Update plant variables
+ */
+void HeightControllerHover::updatePlant(double roll, double pitch, double height)
+{
+  this->roll = roll;
+  this->pitch = pitch;
+  this->height = height;
+}
+
+/*!
+ * @brief Generates thrust command
+ */
+void HeightControllerHover::generate_thrust_command(double linear_controller_output)
+{
+  double thrust_nominal = this->drone_mass * G_CONST;
+  double req_thrust_body = (1 / (cos(this->roll) * cos(this->pitch))) * (thrust_nominal + linear_controller_output);
+  this->thrust_command = req_thrust_body;
+}
+
+double HeightControllerHover::getThrust_command() const
+{
+  return this->thrust_command;
+}

--- a/rotors_control/src/nodes/pid_wrapper.h
+++ b/rotors_control/src/nodes/pid_wrapper.h
@@ -7,6 +7,7 @@
 #include <ros/ros.h>
 
 #include "rotors_control/common.h"
+#include "rotors_control/height_controller_hover.h"
 
 namespace rotors_control
 {
@@ -14,8 +15,8 @@ namespace rotors_control
 class PIDWrapper
 {
 public:
-    PIDWrapper();
-    ~PIDWrapper();
+  PIDWrapper();
+
 
     void InitializeParams();
     void PublishPIDRef();
@@ -29,6 +30,8 @@ private:
     // State estimates
     double height_ = 0.;
     double yaw_ = 0.;
+    double roll_ = 0.;
+    double pitch_ = 0.;
 
     // PID inputs
     double height_ref_ = 0.;
@@ -53,6 +56,11 @@ private:
     ros::Publisher height_ref_pub_;
     ros::Publisher yaw_obs_pub_;
     ros::Publisher height_obs_pub_;
+
+    // Height controller object
+    HeightControllerHover controller_;
+
+
 
     void HeightPIDOutputCallback(const std_msgs::Float64ConstPtr &height_pid_output_msg);
 

--- a/rotors_gazebo/launch/mav_landing_sim.launch
+++ b/rotors_gazebo/launch/mav_landing_sim.launch
@@ -53,11 +53,11 @@
       <remap from="pose_with_covariance" to="odometry_sensor1/pose_with_covariance" />
     </node>
     <node name="height_pid" pkg="pid" type="controller">
-      <param name="Kp" value="7.0" />
-      <param name="Ki" value="2.0" />
-      <param name="Kd" value="4.0" />
-      <param name="upper_limit" value="150" />
-      <param name="lower_limit" value="0" />
+      <param name="Kp" value="1.2" />
+      <param name="Ki" value="0.05" />
+      <param name="Kd" value="3.0" />
+      <param name="upper_limit" value="5" />
+      <param name="lower_limit" value="-5" />
       <param name="windup_limit" value="10" />
       <param name="cutoff_frequency" value="20" />
       <param name="max_loop_frequency" value="105.0" />


### PR DESCRIPTION
Added a height controller class that is integrated into the PID_wrapper node
- height controller consists of a very simple feedback linearization scheme with a PID controller designed around hover 
- same control law as in http://ai.stanford.edu/~gabeh/papers/ICRA09_AeroEffects.pdf but without the term on z-acceleration. 
-tuned gains for slow ascent and descent